### PR TITLE
Fixed install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,5 @@ To install themes :
 
     1) required to install plank
     2) downdload zip file
-    3) copy all the themes and pest it in /home/{ put your username }/.local/pank/themes directory
+    3) copy all the themes and paste it in /home/{ put your username }/.local/share/plank/themes directory
     4) apply themes and enjoy 😀😀😀


### PR DESCRIPTION
The install instructions contained the wrong directory path for Plank themes, updated it with the correct one.